### PR TITLE
Update to Alcotest 1.9.0

### DIFF
--- a/alcotest/junit_alcotest.ml
+++ b/alcotest/junit_alcotest.ml
@@ -32,7 +32,7 @@ let wrap_test ?classname handle_result (name, s, test) =
         exn_msg
       |> handle_result;
       reraise exn
-    | Alcotest_engine__Core.Skip as exn ->
+    | Alcotest_engine.V1.Core.Skip as exn ->
       Junit.Testcase.skipped ~name ~classname ~time:0. |> handle_result;
       reraise exn
     | exn ->

--- a/junit_alcotest.opam
+++ b/junit_alcotest.opam
@@ -10,7 +10,7 @@ tags: ["junit" "jenkins" "alcotest"]
 depends: [
   "dune" {>= "3.0"}
   "odoc" {with-doc & >= "1.1.1"}
-  "alcotest" {>= "1.8.0"}
+  "alcotest" {>= "1.9.0"}
   "junit" {= version}
   "ocamlformat" {= "0.27.0" & with-dev-setup}
 ]


### PR DESCRIPTION
Use exposed `Alcotest_engine.V1.Core.Skip` exception. See https://github.com/mirage/alcotest/pull/416.
Fixes #13 .