### PR TITLE
Measure test execution time in alcotest integration

### DIFF
--- a/alcotest/dune
+++ b/alcotest/dune
@@ -3,4 +3,4 @@
  (public_name junit_alcotest)
  (wrapped false)
  (synopsis "JUnit XML reports generation for alcotest tests")
- (libraries junit alcotest))
+ (libraries junit alcotest unix))

--- a/alcotest/junit_alcotest.ml
+++ b/alcotest/junit_alcotest.ml
@@ -18,29 +18,31 @@ let wrap_test ?classname handle_result (name, s, test) =
     | Some path -> path
   in
   let test () =
+    let start = Unix.gettimeofday () in
+    let elapsed () = Unix.gettimeofday () -. start in
     try
       test ();
-      Junit.Testcase.pass ~name ~classname ~time:0. |> handle_result
+      Junit.Testcase.pass ~name ~classname ~time:(elapsed ()) |> handle_result
     with
     | Failure exn_msg as exn ->
       Junit.Testcase.failure
         ~name
         ~classname
-        ~time:0.
+        ~time:(elapsed ())
         ~typ:"not expected result"
         ~message:"test failed"
         exn_msg
       |> handle_result;
       reraise exn
     | Alcotest_engine.V1.Core.Skip as exn ->
-      Junit.Testcase.skipped ~name ~classname ~time:0. |> handle_result;
+      Junit.Testcase.skipped ~name ~classname ~time:(elapsed ()) |> handle_result;
       reraise exn
     | exn ->
       let exn_msg = Printexc.to_string exn in
       Junit.Testcase.error
         ~name
         ~classname
-        ~time:0.
+        ~time:(elapsed ())
         ~typ:"exception raised"
         ~message:"test crashed"
         exn_msg

--- a/alcotest/test/alcotest_report.expected
+++ b/alcotest/test/alcotest_report.expected
@@ -1,12 +1,12 @@
 <testsuites><testsuite package="junit_alcotest" id="0" name="Skip test suite" timestamp="2013-05-24T10:23:58" hostname="localhost" tests="2" failures="0" errors="0" skipped="2" time="0"><properties></properties><testcase name="Skipped quick" classname="Skip test suite.Skipped tests" time="0"><skipped></skipped></testcase><testcase name="Skipped slow" classname="Skip test suite.Skipped tests" time="0"><skipped></skipped></testcase></testsuite><testsuite package="junit_alcotest" id="1" name="My first test" timestamp="2013-05-24T10:23:58" hostname="localhost" tests="5" failures="0" errors="2" skipped="1" time="0"><properties></properties><testcase name="Test with unexpected exception" classname="My first test.Basic tests" time="0"><error message="test crashed" type="exception raised">Invalid_argument(&quot;7&quot;)</error></testcase><testcase name="Capitalize" classname="My first test.Basic tests" time="0"></testcase><testcase name="Add entries" classname="My first test.Basic tests" time="0"></testcase><testcase name="Test with wrong result" classname="My first test.Basic tests" time="0"><error message="test crashed" type="exception raised">Alcotest assertion failure
-&#27;[1mFile &quot;alcotest/junit_alcotest.ml&quot;, line 22, character 6:
+&#27;[1mFile &quot;alcotest/junit_alcotest.ml&quot;, line 24, character 6:
 &#27;[0m&#27;[31mFAIL&#27;[0m string_of_int equals to '7'
 
    Expected: `&#27;[32m&quot;7&quot;&#27;[0m'
    Received: `&#27;[31m&quot;8&quot;&#27;[0m'
 
 </error></testcase><testcase name="Test skipped" classname="My first test.Basic tests" time="0"><skipped></skipped></testcase></testsuite><testsuite package="junit_alcotest" id="2" name="My second test" timestamp="2013-05-24T10:23:58" hostname="localhost" tests="5" failures="0" errors="2" skipped="1" time="0"><properties></properties><testcase name="Test with unexpected exception" classname="My second test.Basic tests" time="0"><error message="test crashed" type="exception raised">Invalid_argument(&quot;7&quot;)</error></testcase><testcase name="Capitalize" classname="My second test.Basic tests" time="0"></testcase><testcase name="Add entries" classname="My second test.Basic tests" time="0"></testcase><testcase name="Test with wrong result" classname="My second test.Basic tests" time="0"><error message="test crashed" type="exception raised">Alcotest assertion failure
-&#27;[1mFile &quot;alcotest/junit_alcotest.ml&quot;, line 22, character 6:
+&#27;[1mFile &quot;alcotest/junit_alcotest.ml&quot;, line 24, character 6:
 &#27;[0m&#27;[31mFAIL&#27;[0m string_of_int equals to '7'
 
    Expected: `&#27;[32m&quot;7&quot;&#27;[0m'

--- a/alcotest/test/dune
+++ b/alcotest/test/dune
@@ -12,8 +12,15 @@
    (run %{dep:alcotest_report.exe}))))
 
 (rule
+ (targets alcotest_report_normalized.xml)
+ (action
+  (with-stdout-to
+   %{targets}
+   (bash "sed 's/time=\"[^\"]*\"/time=\"0\"/g' %{dep:alcotest_report.xml}"))))
+
+(rule
  (alias runtest)
  (package junit_alcotest)
  (action
-  (diff %{dep:alcotest_report.expected} %{dep:alcotest_report.xml}))
+  (diff %{dep:alcotest_report.expected} %{dep:alcotest_report_normalized.xml}))
  (deps alcotest_report.exe))


### PR DESCRIPTION
Replaces hardcoded `~time:0.` in `junit_alcotest` with actual wall-clock timing using `Unix.gettimeofday`.

Test expectations are normalized with sed to keep diffs stable.

The same approach could be applied to the ounit integration if there's interest — I only use alcotest so started here.